### PR TITLE
Kernel Heap Expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,5 @@ test:
 	@$(MAKE) -C ./kernel test
 
 docs:
-	doxygen doxyfile
-	$(MAKE) -C latex pdf
-	mv ./latex/refman.pdf course_os_docs.pdf
+	doxygen Doxyfile
+	xdg-open docs/index.html

--- a/kernel/src/allocator/include/allocator.h
+++ b/kernel/src/allocator/include/allocator.h
@@ -50,8 +50,8 @@ void create_heap(heap_t * heap, uint32_t start);
 
 void * heap_alloc(heap_t * heap, uint32_t size);
 void heap_free(heap_t * heap, void * p);
-uint32_t expand(heap_t * heap, uint32_t sz);
-void contract(heap_t * heap, uint32_t sz);
+uint32_t expand(heap_t * heap);
+void contract(heap_t * heap);
 
 uint32_t get_bin_index(uint32_t sz);
 void create_foot(node_t * head);

--- a/kernel/src/allocator/mem_alloc.c
+++ b/kernel/src/allocator/mem_alloc.c
@@ -38,7 +38,7 @@ void init_heap() {
     heap_end = ALIGN(heap_end, PAGE_SIZE);
     size_t heap_start = heap_end;
 
-    while (heap_end < (heap_start + HEAP_INIT_SIZE + PAGE_SIZE)) {
+    while (heap_end < (heap_start + HEAP_INIT_SIZE)) {
         if (vm2_allocate_page(kernell1PageTable,
                               heap_end,
                               false,

--- a/kernel/src/allocator/test/test_allocator.c
+++ b/kernel/src/allocator/test/test_allocator.c
@@ -32,3 +32,21 @@ TEST_CREATE(test_calloc, {
 
     kfree(test);
 })
+
+TEST_CREATE(test_expand_heap, {
+    uint32_t initial_end = heap->end;
+
+    expand(heap);
+
+    ASSERT_EQ(heap->end, initial_end + 0x1000);
+
+    uint8_t * yolo = (void *)(heap->end - 300);
+    uint8_t prev = *yolo;
+    *yolo = 42;
+    ASSERT_EQ(*yolo, 42);
+    *yolo = prev;
+
+    contract(heap);
+
+    ASSERT_EQ(heap->end, initial_end);
+})

--- a/kernel/src/fs/include/file.h
+++ b/kernel/src/fs/include/file.h
@@ -5,6 +5,8 @@
 #include <fs.h>
 #include <vp_array_list.h>
 
+#include "path.h"
+
 struct FsOperations;
 
 typedef struct File {

--- a/kernel/src/vm/include/vm2.h
+++ b/kernel/src/vm/include/vm2.h
@@ -306,7 +306,7 @@ bool vm2_l1_map_physical_to_virtual(struct L1PageTable * pt,
 /// the same n megabytes in which some mmio is located. Returns the virtual address.
 size_t vm2_map_peripheral(size_t physical, size_t n_mebibytes);
 
-/// Maps a new 4KiB page with kernel permissions at a virtual address. Returns a reference to this
+/// Maps a new 4KiB page at a virtual address. Returns a reference to this
 /// page or NULL if unsuccessful. The physical location of this page is determined by the
 /// [PMM](pmm.c). Since this allocates a 4KiB page, it has to go through L2Pagetables. It will
 /// create the right L2 pagetables as it needs. You can make the allocated page executable with the
@@ -318,6 +318,15 @@ void * vm2_allocate_page(struct L1PageTable * l1pt,
                          bool remap,
                          struct PagePermission perms,
                          struct L2PageTable ** created_l2pt);
+
+/// Frees a 4KiB page at a virtual address. The address does not need to be aligned. If the address
+/// is not aligned, the aligned 4KiB page the address lies in is freed.
+/// TODO: Does not yet free l2 pagetables when they become empty after enough pages are freed. For
+/// TODO: processes this is never necessary as their pagetables are freed whenever the process
+/// stops. For
+/// TODO: the kernel it might be necessary.
+/// Automatically unmaps the page from the l1pt it was in.
+void vm2_free_page(struct L1PageTable * l1pt, size_t virtual);
 
 /// Should be called after updating a pagetable.
 void vm2_flush_caches();

--- a/kernel/src/vm/test/test_pagealloc2.c
+++ b/kernel/src/vm/test/test_pagealloc2.c
@@ -48,11 +48,11 @@ TEST_CREATE(test_allocate_many_pt, {
     size_t total = listlength(physicalMemoryManager.unused);
     size_t totalallocated = listlength(physicalMemoryManager.allocated);
 
-    const size_t amount = 1026;
+    const size_t amount = 520;
 
     struct L1PageTable * pages[amount];
 
-    for (int i = 0; i < amount; i++) {
+    for (size_t i = 0; i < amount; i++) {
         pages[i] = pmm_allocate_l1_pagetable();
         ASSERT_NOT_NULL(pages[i]);
         ASSERT_EQ(listlength(physicalMemoryManager.unused), total - (i + 1u));

--- a/scripts/clang-format-all.sh
+++ b/scripts/clang-format-all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+shopt -s globstar
+
+DIR=$(dirname "$0")/..
+
+eval clang-format -style=file $DIR/kernel/**/*.{c,h} -i
+


### PR DESCRIPTION
Actually implemented the methods so that the kernel heap can grow and contract based on what is needed.

Also added config for clang-format to lint our code.