### PR TITLE
Memory detection

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -8,7 +8,7 @@ CFLAGS += -pipe -std=gnu99 -ffreestanding -Wall -Werror -g -O0 -mcpu=arm1176jzf-
 #PI_CFLAGS = -mfpu=vfp -march=armv6zk -mtune=arm1176jzf-s -nostartfiles
 
 # variables to define in the preprocessor.
-MEMORY = 512M
+MEMORY = 1G
 LOG_LEVEL ?= 4
 DEFINITIONS = MEM_DEBUG LOG_LEVEL=${LOG_LEVEL}
 test: DEFINITIONS += ENABLE_TESTS # if we execute the test: rule, enable tests before recompiling

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -8,7 +8,7 @@ CFLAGS += -pipe -std=gnu99 -ffreestanding -Wall -Werror -g -O0 -mcpu=arm1176jzf-
 #PI_CFLAGS = -mfpu=vfp -march=armv6zk -mtune=arm1176jzf-s -nostartfiles
 
 # variables to define in the preprocessor.
-MEMORY = 1G
+MEMORY = 512M
 LOG_LEVEL ?= 4
 DEFINITIONS = MEM_DEBUG LOG_LEVEL=${LOG_LEVEL}
 test: DEFINITIONS += ENABLE_TESTS # if we execute the test: rule, enable tests before recompiling

--- a/kernel/linker/kernel.ld
+++ b/kernel/linker/kernel.ld
@@ -10,8 +10,10 @@ SECTIONS
     .boot : {
         */startup.o (.text)
         */startup.o (.data)
-        */stacks.o (.text)
         */startup.o (.bss)
+        */stacks.o (.text)
+        */memory.o (.text)
+        */memory.o (.data)
     }
     __BOOT_END = .;
     . += __KERNEL_VIRTUAL_OFFSET;

--- a/kernel/src/common/memory.s
+++ b/kernel/src/common/memory.s
@@ -2,7 +2,7 @@
 .global detect_memory
 // Detects the size of physical memory. Returns it's answer in bytes in r1
 detect_memory:
-    push {r0, r2, r3, r4, lr}
+    push {r0, r2, r3, r4, r5, lr}
 
     // Load 0 in R0. R0 is used as a counter which we increase with
     // a mebibyte at a time to search the address space.
@@ -16,6 +16,42 @@ detect_memory:
 detect_memory_loop:
     // Add the increment
     add r0, r0, r3
+
+    // Is this address in one of the forbidden regions?
+    ldr r4, =mmio_regions_start
+detect_memory_forbidden_loop:
+    // Load the start value
+    ldr r5, [r4]
+    // Add 4 to get to the end address of the region
+    add r4, r4, #4
+
+    // If the current address is greater than this it might be in the region
+    cmp r0, r5
+    bge detect_memory_forbidden_loop_maybe_forbidden
+detect_memory_forbidden_loop_not_forbidden:
+    // Else just skip the end
+    add r4, r4, #4
+
+    // Check if we're done first
+    ldr r5, =mmio_regions_end
+    cmp r4, r5
+    bge detect_memory_forbidden_loop_done
+    // if not, continue with the next entry in the forbidden regions array
+    b detect_memory_forbidden_loop
+
+detect_memory_forbidden_loop_maybe_forbidden:
+    ldr r5, [r4]
+
+    // If the current address is greater than the end address, it's not forbidden and we can continue.
+    cmp r0, r5
+    bge detect_memory_forbidden_loop_not_forbidden
+
+    // The region is forbidden.
+    // set the current address to the end address which is guaranteed not to be forbidden anymore
+    mov r0, r5
+    /* FallThrough */
+
+detect_memory_forbidden_loop_done:
 
     // Write the value 42 at the current address
     mov r1, #42
@@ -50,14 +86,20 @@ detect_memory_loop_done:
     // Put the result in r1
     mov r1, r0
 
-    pop {r0, r2, r3, r4, pc}
+    pop {r0, r2, r3, r4, r5, pc}
+
 
 .data
 max_memory_size: .long 0x40000000
 // 2-tuples representing forbidden memory regions.
-// TODO: Actually check for these regions. Rn it just works by chance :/
-mmio_regions:
+// First long is the start address (inclusive)
+// Second long is the end address (exclusive)
+mmio_regions_start:
+    // On qemu the second-to-last megabyte seems to be unusable
+    // TODO: why?
+    .long 0x3fe00000
+    .long 0x3ff00000
+
     // BCM2836 regions
-    //.long 0x
 
 mmio_regions_end:

--- a/kernel/src/common/memory.s
+++ b/kernel/src/common/memory.s
@@ -1,0 +1,63 @@
+.text
+.global detect_memory
+// Detects the size of physical memory. Returns it's answer in bytes in r1
+detect_memory:
+    push {r0, r2, r3, r4, lr}
+
+    // Load 0 in R0. R0 is used as a counter which we increase with
+    // a mebibyte at a time to search the address space.
+    // We skip addresses in the `mmio regions` array.
+    ldr r0, =0x00000000
+
+    // r3 represents the increment that's taken every iteration.
+    // It will go down as we reach the end until it's 0 and we found the absolute end.
+    ldr r3, =0x10000000
+
+detect_memory_loop:
+    // Add the increment
+    add r0, r0, r3
+
+    // Write the value 42 at the current address
+    mov r1, #42
+    str r1, [r0]
+    // Read it again
+    ldr r2, [r0]
+    // Is it still 42? then continue.
+    // Else decrease the step size and retry
+    cmp r2, r1
+    beq detect_memory_continue_loop
+
+    // First subtract the previous stepsize
+    sub r0, r0, r3
+    // Divide the increment by 2
+    asr r3, r3, #1
+
+    // Is the increment zero? then stop. We found the end of ram
+    cmp r3, #0
+    beq detect_memory_loop_done
+
+    // retry
+    b detect_memory_loop
+
+detect_memory_continue_loop:
+    ldr r1, =max_memory_size
+    ldr r1, [r1]
+    cmp r0, r1
+
+    blt detect_memory_loop
+detect_memory_loop_done:
+
+    // Put the result in r1
+    mov r1, r0
+
+    pop {r0, r2, r3, r4, pc}
+
+.data
+max_memory_size: .long 0x40000000
+// 2-tuples representing forbidden memory regions.
+// TODO: Actually check for these regions. Rn it just works by chance :/
+mmio_regions:
+    // BCM2836 regions
+    //.long 0x
+
+mmio_regions_end:

--- a/kernel/src/common/stacks.s
+++ b/kernel/src/common/stacks.s
@@ -17,32 +17,32 @@
 .global stacks
 stacks:
    // FIQ Stack
-    MSR CPSR_c, #Mode_FIQ // Switch to FIQ Mode
-    LDR sp, =FIQ_STACK_TOP // Set the FIQ stack pointer
+    msr CPSR_c, #Mode_FIQ // Switch to FIQ Mode
+    ldr sp, =FIQ_STACK_TOP // Set the FIQ stack pointer
 
     // IRQ Stack
-    MSR CPSR_c, #Mode_IRQ
-    LDR sp, =IRQ_STACK_TOP
+    msr CPSR_c, #Mode_IRQ
+    ldr sp, =IRQ_STACK_TOP
 
     // MON Stack
-    MSR CPSR_c, #Mode_MON
-    LDR sp, =MON_STACK_TOP
+    msr CPSR_c, #Mode_MON
+    ldr sp, =MON_STACK_TOP
 
     // ABT Stack
-    MSR CPSR_c, #Mode_ABT
-    LDR sp, =ABT_STACK_TOP
+    msr CPSR_c, #Mode_ABT
+    ldr sp, =ABT_STACK_TOP
 
     // UND Stack
-    MSR CPSR_c, #Mode_UND
-    LDR sp, =UND_STACK_TOP
+    msr CPSR_c, #Mode_UND
+    ldr sp, =UND_STACK_TOP
 
     // SYS Stack
-    MSR CPSR_c, #Mode_SYS
-    LDR sp, =SYS_STACK_TOP
+    msr CPSR_c, #Mode_SYS
+    ldr sp, =SYS_STACK_TOP
 
     // Switch back SVC/Kernel
-    MSR CPSR_c, #Mode_SVC
-    ADD fp, sp, #0 // ???
+    msr CPSR_c, #Mode_SVC
+    add fp, sp, #0 // ???
 
     bx lr
 

--- a/kernel/src/common/start.c
+++ b/kernel/src/common/start.c
@@ -10,7 +10,7 @@
 /// Entrypoint for the C part of the kernel.
 /// This function is called by the assembly located in [startup.s].
 /// The MMU has already been initialized here but only the first MiB of the kernel has been mapped.
-void start(uint32_t * p_bootargs) {
+void start(uint32_t * p_bootargs, size_t memory_size) {
     // Before this point, all code has to be hardware independent.
     // After this point, code can request the hardware info struct to find out what
     // Code should be ran.
@@ -19,6 +19,7 @@ void start(uint32_t * p_bootargs) {
     // Initialize the chipset and enable uart
     init_chipset();
 
+    INFO("Detected memory size: 0x%x Bytes", memory_size);
     INFO("Started chipset specific handlers");
 
     // just cosmetic (and for debugging)

--- a/kernel/src/common/startup.s
+++ b/kernel/src/common/startup.s
@@ -10,7 +10,12 @@ _Reset:
     bne loop
 
     ldr sp, =EARLY_KERNEL_STACK_TOP // Set the kernel/SVC stack
+
+    // Detect memory size
+    bl detect_memory
+
     push {r0-r11}
+
 
     // Identity map 0x00000000 (the kernel)
     ldr r0, =0x4000
@@ -63,8 +68,12 @@ _Reset:
     ldr sp, =KERNEL_STACK_TOP // Set the kernel/SVC stack
     push {r0-r11}
 
-    // Setup
+    // Setup stacks
     bl stacks
+
+    // Pop everything except r1, which will hold the memory size.
+    pop {r0}
+    pop {r2-r11}
 
     // Jumpt to the start of the kernel
     bl start

--- a/kernel/src/drivers/chipset/bcm2836/uart.c
+++ b/kernel/src/drivers/chipset/bcm2836/uart.c
@@ -1,6 +1,5 @@
 #include <bcm2836.h>
 #include <chipset.h>
-#include <interrupt.h>
 #include <limits.h>
 
 /*

--- a/kernel/src/fs/include/file.h
+++ b/kernel/src/fs/include/file.h
@@ -2,7 +2,7 @@
 #ifndef FILE_H
 #define FILE_H
 
-#include <fs.h>
+#include <path.h>
 #include <vp_array_list.h>
 
 struct FsOperations;


### PR DESCRIPTION
This PR adds the ability for the kernel to scan the address space in `O(log(n))` time to find how much it has available. It does so in `memory.s`. It passes this size to `void start()` in `start.c` so it can be used.

This system executes before jumping to the higher half kernel.

Todos:

* [x] Add a list of regions in memory that cannot be scanned because they might contain mmio devices. This list must include regions that can be used in any of the processors and boards supported. That includes the BCM2835 and BCM2836.
* [ ] Actually make the PMM use the info memory detection finds.
