### PR TITLE
Fix CMake compiler and linker detection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ project(course_os)
 
 set(CMAKE_SYSTEM_NAME linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
-set(CMAKE_C_COMPILER ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/arm-none-eabi/bin/arm-none-eabi-gcc)
-set(CMAKE_C_LINK_EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/arm-none-eabi/bin/arm-none-eabi-ld)
+set(CMAKE_C_COMPILER ${CMAKE_CURRENT_SOURCE_DIR}/src/toolchain/arm-none-eabi/bin/arm-none-eabi-gcc)
+set(CMAKE_C_LINK_EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/src/toolchain/arm-none-eabi/bin/arm-none-eabi-ld)
 
 file(GLOB_RECURSE kernel_sources ./src/kernel/src/*.c ./src/kernel/src/**/*.c)
 file(GLOB_RECURSE kernel_include LIST_DIRECTORIES true ./src/kernel/src/**/include)


### PR DESCRIPTION
This branch adjusts the path to the compiler and linker used in the CMakeLists.txt file. After that, CLion can again help developers with code completion and include files detection.